### PR TITLE
Improve file types comparison check

### DIFF
--- a/app/Http/Controllers/Admin/TaskController.php
+++ b/app/Http/Controllers/Admin/TaskController.php
@@ -59,7 +59,6 @@ class TaskController extends Controller
      */
     public function store(Request $request, Classes $class)
     {
-        $datatypes = Task::FILE_TYPES;
         $this->validate($request, [
             'title' => 'required|min:5|max:64',
             'description' => 'required|min:3',
@@ -67,17 +66,15 @@ class TaskController extends Controller
             'deadline' => 'required'
         ]);
 
-        foreach ($request->datatypes as $datatype) {
-            if (!in_array($datatype, $datatypes)) {
-                return redirect()->back()->withInput($request->toArray())->with('errors', 'Something error about datatypes');
-            }
+        if (! validateFileTypes($request->datatypes, Task::FILE_TYPES)) {
+            return redirect()->back()->withInput($request->toArray())->with('errors', 'Something error about datatypes');
         }
 
         $deadline = Carbon::parse($request->deadline);
         $token = md5(Str::random(32));
         Storage::disk('minio')->makeDirectory("tasks/$token");
         $link = AssistantShortlink::storeLink(route('task.show', $token));
-        $task = Task::create([
+        Task::create([
             'user_id' => Auth::id(),
             'class_id' => $class->id,
             'title' => $request->title,
@@ -127,18 +124,15 @@ class TaskController extends Controller
 
     public function update(Request $request, Task $task)
     {
-        $datatypes = Task::FILE_TYPES;
         $this->validate($request, [
             'description' => 'required|min:3',
             'datatypes' => 'required',
             'deadline' => 'required'
         ]);
 
-        foreach ($request->datatypes as $datatype) {
-            if (!in_array($datatype, $datatypes)) {
-                toastr()->error('Something error about datatypes');
-                return redirect()->back()->withInput($request->toArray())->with('errors', 'Something error about datatypes');
-            }
+        if (! validateFileTypes($request->datatype, Task::FILE_TYPES)) {
+            toastr()->error('Something error about datatypes');
+            return redirect()->back()->withInput($request->toArray())->with('errors', 'Something error about datatypes');
         }
 
         $task->update([

--- a/app/Http/Controllers/Assistant/TaskController.php
+++ b/app/Http/Controllers/Assistant/TaskController.php
@@ -37,12 +37,12 @@ class TaskController extends Controller
      * Show the form for creating a new resource.
      *
      * @param Classes $class
-     * @return \Illuminate\Http\Response|\Illuminate\View\View
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\View\View
      */
     public function create(Classes $class)
     {
         abort_unless(Auth::user()->can('view', $class), 403);
-        if($class->status !== 1){
+        if ($class->status !== 1){
             return redirect()->back()->with('error', 'Kelas sudah tidak dapat diberi tugas');
         }
 
@@ -62,7 +62,6 @@ class TaskController extends Controller
     {
         abort_unless(Auth::user()->can('view', $class), 403);
 
-        $datatypes = Task::FILE_TYPES;
         $this->validate($request, [
             'title' => 'required|min:5|max:64',
             'description' => 'required|min:3',
@@ -70,10 +69,8 @@ class TaskController extends Controller
             'deadline' => 'required'
         ]);
 
-        foreach ($request->datatypes as $datatype) {
-            if (!in_array($datatype, $datatypes)) {
-                return redirect()->back()->withInput($request->toArray())->with('errors', 'Something error about datatypes');
-            }
+        if (! validateFileTypes($request->datatypes, Task::FILE_TYPES)) {
+            return redirect()->back()->withInput($request->toArray())->with('errors', 'Something error about datatypes');
         }
 
         $deadline = Carbon::parse($request->deadline);
@@ -151,11 +148,9 @@ class TaskController extends Controller
             'deadline' => 'required'
         ]);
 
-        foreach ($request->datatypes as $datatype) {
-            if (!in_array($datatype, Task::FILE_TYPES)) {
-                toastr()->error('Something error about datatypes');
-                return redirect()->back()->withInput($request->toArray())->with('errors', 'Something error about datatypes');
-            }
+        if (! validateFileTypes($request->datatypes, Task::FILE_TYPES)) {
+            toastr()->error('Something error about datatypes');
+            return redirect()->back()->withInput($request->toArray())->with('errors', 'Something error about datatypes');
         }
 
         $task->update([

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -60,7 +60,7 @@ class TaskController extends Controller
             return json_response(0, "Tugas tidak ditemukan");
         }
 
-        if (!in_array($file->getClientOriginalExtension(), explode('|', $task->data_types))) {
+        if (! validateFileTypes($file->getClientOriginalExtension(), $task->datatype_list)) {
             return json_response(0, "Format File Salah");
         }
 

--- a/app/Http/Helper.php
+++ b/app/Http/Helper.php
@@ -52,3 +52,44 @@ if (!function_exists('error_response')) {
         return json_response(0, "Something error", compact('errors'));
     }
 }
+
+if (! function_exists('in_arrayi')) {
+    /**
+     * Case-insensitive in_array wrapper.
+     *
+     * @param   mixed $needle   Value to seek.
+     * @param   array $haystack Array to seek in.
+     *
+     * @return bool
+     */
+    function in_arrayi($needle, array $haystack): bool
+    {
+        return in_array(strtolower($needle), array_map('strtolower', $haystack), false);
+    }
+}
+
+if (! function_exists('validateFileTypes')) {
+    /**
+     * Does $type exist in $dataTypes?
+     *
+     * @param mixed $types      Type to check.
+     * @param array $validTypes List of valid types.
+     *
+     * @return bool
+     */
+    function validateFileTypes($types, array $validTypes): bool
+    {
+        if (! is_array($types)) {
+            return in_arrayi($types, $validTypes);
+        }
+
+        foreach ($types as $type) {
+            if (! in_arrayi($type, $validTypes)) {
+                return false;
+            }
+            continue;
+        }
+
+        return true;
+    }
+}

--- a/app/Task.php
+++ b/app/Task.php
@@ -76,11 +76,16 @@ class Task extends Model
         return $this->hasMany('App\TaskSubmission');
     }
 
+    public function getDataTypeListAttribute()
+    {
+        return explode('|', $this->data_types);
+    }
+
     public function getFileTypeFormatAttribute(){
         $temp = [];
-        foreach (explode("|", $this->data_types) as $type){
-            array_push($temp, ".$type");
+        foreach ($this->getDataTypeListAttribute() as $type){
+            $temp[] = ".$type";
         }
-        return implode(",", $temp);
+        return implode(',', $temp);
     }
 }


### PR DESCRIPTION
This PR should fix issue #49.

Summary:
- Added 2 helpers function
  - `in_arrayi()` - case insensitive version of in_array
  - `validateFileTypes()` - compare a given extension with the valid list
- Some updates on App\Task
  - `getDataTypeListAttribute()` - new attribute as array for data_types.
  - `getFileTypeFormatAttribute()` -  change `array_push($temp, ".$type");` with `$temp[] = ".$type"`. _Phpstorm says this is the faster way_
- Update TaskController.
  - `App/Http/Controllers/TaskController.php` - implements `validateFileTypes()`
  - `App/Http/Controllers/Admin/TaskController.php` - implements `validateFileTypes()`
  - `App/Http/Controllers/Assistant/TaskController.php` - implements `validateFileTypes()`